### PR TITLE
[Feature] 가입-약관동의 화면 기능 구현 #14

### DIFF
--- a/baemin-register/app.js
+++ b/baemin-register/app.js
@@ -1,46 +1,47 @@
-var createError = require('http-errors');
-var express = require('express');
-var path = require('path');
-var cookieParser = require('cookie-parser');
-var logger = require('morgan');
+var createError = require("http-errors");
+var express = require("express");
+var path = require("path");
+var cookieParser = require("cookie-parser");
+var logger = require("morgan");
 
-var indexRouter = require('./routes/index');
-var authRouter = require('./routes/auth');
+var indexRouter = require("./routes/index");
+var authRouter = require("./routes/auth");
 
 var app = express();
 
 // view engine setup
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'ejs');
+app.set("views", path.join(__dirname, "views"));
+app.set("view engine", "ejs");
 
 // TODO: add Express Session middleware
 // TODO: add Embeded DB middleware
+// TODO: add BodyParser middleware
 
-app.use(logger('dev'));
+app.use(logger("dev"));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, "public")));
 
-app.use('/', indexRouter);
-app.use('/auth', authRouter);
+app.use("/", indexRouter);
+app.use("/auth", authRouter);
 
 // TODO: Add API (/user/id)
 
 // catch 404 and forward to error handler
-app.use(function(req, res, next) {
+app.use(function (req, res, next) {
   next(createError(404));
 });
 
 // error handler
-app.use(function(err, req, res, next) {
+app.use(function (err, req, res, next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
+  res.locals.error = req.app.get("env") === "development" ? err : {};
 
   // render the error page
   res.status(err.status || 500);
-  res.render('error');
+  res.render("error");
 });
 
 module.exports = app;

--- a/baemin-register/public/javascripts/login/index.js
+++ b/baemin-register/public/javascripts/login/index.js
@@ -51,10 +51,6 @@ function bindEvents() {
   $loginBtn.addEventListener("click", handleLoginBtnClick);
 }
 
-function main() {
-  bindEvents();
-}
-
 window.addEventListener("DOMContentLoaded", () => {
   bindEvents();
 });

--- a/baemin-register/public/javascripts/registerTerms/index.js
+++ b/baemin-register/public/javascripts/registerTerms/index.js
@@ -1,13 +1,65 @@
-function handleNextPageClick() {
-  location.href = "/auth/registerPhone";
-}
+import { delegate } from "../utils/eventHelper.js";
 
-function bindingEvents() {
-  console.log("event binding");
-  const nextButtonDOM = document.querySelector(".next-step-btn");
-  nextButtonDOM.addEventListener("click", handleNextPageClick);
-}
+const tag = "[registerTerms]";
 
-window.onload = () => {
-  bindingEvents();
+const isCheckedAllEssentialTerms = () => {
+  const nodeList = document.querySelectorAll(".essential-terms");
+
+  const termsCheckBoxList = Array.from(nodeList);
+
+  const checkedTermsCheckBoxes = termsCheckBoxList.filter(
+    ($checkbox) => $checkbox.checked
+  );
+
+  return termsCheckBoxList.length === checkedTermsCheckBoxes.length;
 };
+
+const validateActivatableNextButton = () => {
+  const $submitBtn = document.querySelector("#terms-submit-btn");
+  if (isCheckedAllEssentialTerms()) {
+    $submitBtn.removeAttribute("disabled");
+  } else {
+    $submitBtn.setAttribute("disabled", false);
+  }
+};
+
+const checkAllTerms = () => {
+  const allCheckBoxes = document.querySelectorAll("input[type='checkbox']");
+  Array.from(allCheckBoxes).forEach((checkbox) => {
+    checkbox.checked = true;
+  });
+  validateActivatableNextButton();
+};
+
+const uncheckAllTerms = () => {
+  const allCheckBoxes = document.querySelectorAll("input[type='checkbox']");
+  Array.from(allCheckBoxes).forEach((checkbox) => {
+    checkbox.checked = false;
+  });
+  validateActivatableNextButton();
+};
+
+const handleCheckTermInput = (e) => {
+  validateActivatableNextButton();
+};
+
+const handleCheckAllAgreeInput = (e) => {
+  if (e.target.checked) {
+    checkAllTerms();
+  } else {
+    uncheckAllTerms();
+  }
+};
+
+function bindEvents() {
+  const $termsContainer = document.querySelector("#terms-container");
+  delegate($termsContainer, "input", ".essential-terms", handleCheckTermInput);
+
+  const $allAgreeCheckBox = document.querySelector("#all-agree-checkbox");
+  $allAgreeCheckBox.addEventListener("input", handleCheckAllAgreeInput);
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  bindEvents();
+  uncheckAllTerms();
+});

--- a/baemin-register/public/javascripts/utils/eventHelper.js
+++ b/baemin-register/public/javascripts/utils/eventHelper.js
@@ -1,0 +1,12 @@
+// Event Delegator
+export const delegate = (parent, event, selector, handler) => {
+  const eventDelegator = (e) => {
+    const potentialElements = parent.querySelectorAll(selector);
+    for (const potentialElement of potentialElements) {
+      if (potentialElement === e.target) {
+        return handler.call(e.target, e);
+      }
+    }
+  };
+  parent.addEventListener(event, eventDelegator);
+};

--- a/baemin-register/public/stylesheets/registerTerms.css
+++ b/baemin-register/public/stylesheets/registerTerms.css
@@ -14,6 +14,12 @@ body {
   background-color: white;
   border: none;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex-grow: 1;
 }
 
 header {
@@ -125,16 +131,16 @@ header > .title {
 
 .next-step-btn {
   position: absolute;
-  bottom: 2rem;
+  bottom: 10px;
   width: 100%;
   height: 8%;
   border-radius: 15px;
   border-style: none;
-  background-color: gray;
+  background-color: var(--main-color);
   color: white;
   font-size: 3rem;
 }
 
-.next-step-btn.active {
-  background-color: var(--main-color);
+.next-step-btn:disabled {
+  background-color: var(--disabled-color);
 }

--- a/baemin-register/routes/auth.js
+++ b/baemin-register/routes/auth.js
@@ -1,24 +1,29 @@
-var express = require('express');
+var express = require("express");
 var router = express.Router();
 
 /* GET login page. */
-router.get('/login', function(req, res, next) {
-    res.render('auth/login', { title: 'Login' });
+router.get("/login", function (req, res, next) {
+  res.render("auth/login", { title: "Login" });
 });
 
 /* GET registerTerms page. */
-router.get('/registerTerms', function(req, res, next) {
-    res.render('auth/registerTerms', { title: 'Register Terms' });
+router.get("/registerTerms", function (req, res, next) {
+  res.render("auth/registerTerms", { title: "Register Terms" });
+});
+
+/* POST registerTerms page. */
+router.post("/registerTerms", function (req, res, next) {
+  res.redirect("/auth/registerPhone");
 });
 
 /* GET registerPhone page. */
-router.get('/registerPhone', function(req, res, next) {
-    res.render('auth/registerPhone', { title: 'Register Phone' });
+router.get("/registerPhone", function (req, res, next) {
+  res.render("auth/registerPhone", { title: "Register Phone" });
 });
 
 /* GET registerDetail page. */
-router.get('/registerDetail', function(req, res, next) {
-    res.render('auth/registerDetail', { title: 'Register Detail' });
+router.get("/registerDetail", function (req, res, next) {
+  res.render("auth/registerDetail", { title: "Register Detail" });
 });
-  
+
 module.exports = router;

--- a/baemin-register/views/auth/registerTerms.ejs
+++ b/baemin-register/views/auth/registerTerms.ejs
@@ -7,6 +7,7 @@
       crossorigin="anonymous"
     ></script>
     <link rel="stylesheet" href="/stylesheets/registerTerms.css" />
+    <script type="module" defer src="/javascripts/registerTerms/index.js"></script>
   </head>
   <body>
     <div class="container">
@@ -23,16 +24,16 @@
           <p>약관 동의가 필요해요</p>
         </div>
 
-        <form class="terms-form">
+        <form id="terms-container" class="terms-form" action="/auth/registerTerms" method="POST">
           <div class="check-container">
-            <input type="checkbox" id="all-agree" name="all-agree-checkbox" />
-            <label for="all-agree"> 전체 동의 </label>
+            <input type="checkbox" id="all-agree-checkbox" name="all-agree-checkbox" />
+            <label for="all-agree-checkbox"> 전체 동의 </label>
           </div>
 
           <hr />
 
           <div class="check-container">
-            <input type="checkbox" id="terms-1"  name="terms-1" checked />
+            <input type="checkbox" id="terms-1"  name="terms-1" class="essential-terms" />
             <label for="terms-1">배달의 민족 이용약관 동의</label>
             <button class="check-container--detail-arrow">
               <i class="fas fa-chevron-right"></i>
@@ -40,7 +41,7 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="terms-2" name="terms-2" checked />
+            <input type="checkbox" id="terms-2" name="terms-2" class="essential-terms" />
             <label for="terms-2">전자금융거래 이용약관 동의</label>
             <button class="check-container--detail-arrow">
               <i class="fas fa-chevron-right"></i>
@@ -48,7 +49,7 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="terms-3" name="terms-3" checked />
+            <input type="checkbox" id="terms-3" name="terms-3" class="essential-terms" />
             <label for="terms-3">개인정보 수집이용 동의</label>
             <button class="check-container--detail-arrow">
               <i class="fas fa-chevron-right"></i>
@@ -56,8 +57,8 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="terms-4" name="terms-4" />
-            <label for="terms-4"
+            <input type="checkbox" id="option-terms-1" name="option-terms-1" />
+            <label for="option-terms-1"
               >개인정보 제3자 제공 동의 (선택)</label
             >
             <button class="check-container--detail-arrow">
@@ -66,8 +67,8 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="terms-5" name="terms-5" />
-            <label for="terms-5"
+            <input type="checkbox" id="option-terms-2" name="option-terms-2" />
+            <label for="option-terms-2"
               >마케팅 정보 메일, SMS 수신 동의 (선택)</label
             >
             <button class="check-container--detail-arrow">
@@ -78,28 +79,24 @@
           <hr />
 
           <div class="radio-container">
-            <input type="radio" id="age-over" name="age-retrict" value="over">
-            <label class="radio-container--label"  for="age-over">
+            <input type="radio" id="age-over-radio" name="age" value="over" checked>
+            <label class="radio-container--label"  for="age-over-radio">
               <p class="radio-container--label--title"> 만 14세 이상입니다.</p>
              </label>
           </div>
           <div class="radio-container">
-            <input type="radio" id="age-down" name="age-retrict" value="down">
+            <input type="radio" id="age-down-radio" name="age" value="down">
 
-            <label class="radio-container--label" for="age-down" >
+            <label class="radio-container--label" for="age-down-radio" >
               <p class="radio-container--label--title">만 14세 미만입니다.</p>
               <p class="radio-container--label--subtitle">
                 본인확인이 된 보호자의 배민 계정이 필요해요
               </p>
-            </div>
+            </label>
           </div>
-        
-
-          <input type="submit" class="next-step-btn active" value="다음으로"></button>
+          <input id="terms-submit-btn" type="submit" class="next-step-btn" value="다음으로" disabled></button>
         </form>
       </main>
     </div>
-
-    <script src="/javascripts/registerTerms/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
#14 

## 개요

가입-약관 동의 화면 기능 구현에 대한 PR 입니다. 이번 PR은 자바스크립트로 구현한 함수들이 꽤 있지만 기능은 복잡하지 않습니다.

최대한 의미있는 단위로 함수를 나눴습니다.

그리고  `eventHelper.js`라는 파일을 `javascripts/utils` 폴더에 넣어놨는데  event 위임에 유용한 유틸성 함수하나를 생성해놨습니다.

부모 Element에서 자식 element의 이벤트를 listen하고 싶을 경우 사용하시면 유용할 것 같습니다. 피드백 주시면 감사하겠습니다.

@edegiil  

## 변경사항

기획서에서 정의된 요구사항은 아래와 같습니다.

>필수 항목이 모두 선택되면 하단 ‘다음으로' 버튼이 활성화 된다.
>전체 동의를 누르면 모두 선택된다.  다시 누르면 모두 해제된다

하지만 아래와 같이 추가적으로 고려될 만한 요구사항들도 있었습니다. 

- 약관 동의 정보를 db에 저장해야할가? => 백엔드 구현시 세션에 데이터를 넣어두는 방식을 생각해봐야합니다.
- 브라우저의 뒤로가기를 했을 때 체크했던 박스들을 초기화 시켜줘야하는가? => 저는 모두 초기화했습니다. 
- **전체 동의를 해제했을 때, 체크되있던 체크박스들이 unchecked** 되어야하는가? =>  이부분은 모호함이 존재하지만 아마 체크 해제했을 때 다른 체크박스모두 해제되는게 더좋은 UX가 될 것 같아서 그렇게 진행했습니다.

## 참고사항

expressjs의 router/auth.js 라우터 모듈에 `POST /auth/registerTerms` 라우터 미들웨어를 추가했고 동작방식은 `/auth/registerPhone`으로 Redirect되도록 했습니다. 

## 추가 구현 필요사항

POST 요청으로 query가 제대로 넘어오는지 테스트를 해보려는데 `bodyParser` 모듈이 없어서 바디 정보를 조회할 수없습니다.
백엔드 세팅때 미들웨어 설정에 추가해야할 것 같습니다. 

## 스크린샷

<img width="435" alt="스크린샷 2021-07-07 오후 5 42 05" src="https://user-images.githubusercontent.com/20085849/124728579-adb7a600-df4a-11eb-90e0-3ce30e2ab9a8.png">

