### PR TITLE
BUGFIX: 휴대전화번호 검증 실패 버그 해결

### DIFF
--- a/baemin-register/public/javascripts/registerPhone/index.js
+++ b/baemin-register/public/javascripts/registerPhone/index.js
@@ -67,7 +67,7 @@ function disableNextStep() {
   $headerNextButton.removeEventListener('click', handleSubmit);
 }
 
-function displayValidation($parentElement) {
+function displayValidationMark($parentElement) {
   const $validationMark = document.createElement('i');
   $validationMark.classList.add('fas', 'fa-check', 'check-icon');
 
@@ -75,7 +75,7 @@ function displayValidation($parentElement) {
   $inputFloatButtonWrapper.append($validationMark);
 }
 
-function undisplayValidation($parentElement) {
+function undisplayValidationMark($parentElement) {
   if (state.isPhoneNumberValidate) {
     const $checkIcon = $parentElement.querySelector('.input-float-button-wrapper .check-icon');
     $checkIcon.remove();
@@ -120,14 +120,14 @@ function handlePhoneNumberInput({target}) {
   }
 
   if (inputValue.length !== PHONE_NUMBER_MAX_LENGTH) {
-    undisplayValidation(target.parentElement);
+    undisplayValidationMark(target.parentElement);
     resetValidation();
   }
   if (inputValue.length === PHONE_NUMBER_MAX_LENGTH) {
     const isValid = validatePhoneNumber();
     if (isValid) {
       state.isPhoneNumberValidate = true;
-      displayValidation(target.parentElement);
+      displayValidationMark(target.parentElement);
     }
   }
 }

--- a/baemin-register/public/javascripts/utils/checkRegex.js
+++ b/baemin-register/public/javascripts/utils/checkRegex.js
@@ -6,7 +6,8 @@ const EMAIL_REGEX = {
 } 
 const PHONE_REGEX = {
   regex: '^[0][1][0-9]-\\d{4}-\\d{4}$',
-  isMath: true,
+  flag: 'g',
+  isMatch: true,
 }
 const PASSWORD_COMBINATION_REGEX = {
   regex: '^(((?=.*[a-z])(?=.*[A-Z]))' +
@@ -31,7 +32,6 @@ const BIRTHDAY_REGEX = {
 const testRegex = (regexList) => (string) => {
   const isPassedAll = regexList.reduce((result, regexObject) => {
     const {regex, flag, isMatch} = regexObject;
-    console.log(new RegExp(regex, flag));
     const isOk = new RegExp(regex, flag).test(string);
 
     return result && (isOk === isMatch);

--- a/baemin-register/views/auth/registerPhone.ejs
+++ b/baemin-register/views/auth/registerPhone.ejs
@@ -19,9 +19,9 @@
 <body>
   <div class="container">
     <header>
-      <div class="left">
+      <a class="left" href="/auth/registerTerms">
         <i class="fas fa-arrow-left"></i>
-      </div>
+      </a>
         <div class="title">회원가입</div>
         <div class="right disabled">다음</div>
     </header>
@@ -40,21 +40,10 @@
             </div>
           </label>
         </div>
-        <!-- <div class="input-container">
-          <label for="confirm-number">
-            인증번호
-            <div class="input-wrapper">
-              <input id="confirm-number" type="text">
-            </div>
-          </label>
-        </div> -->
       </form>
       <button class="full-button" id="confirm-number-request">
         인증번호 받기
       </button>
-      <!-- <button class="right-button text-button" id="confirm-number-re-request">
-        인증번호 다시받기
-      </button> -->
     </main>
   </div>
 </body>


### PR DESCRIPTION
#15 

## 개요
휴대전화번호 포맷 검증 실패 버그 해결

## 변경사항
* 정규표현식 체크 모듈 변수 명 수정
* 뒤로가기 버튼 구현
* 기타 코드 정리 (주석 제거, `console.log()` 제거)

## 참고사항
버그는 정규표현식 체크 모듈에서 정규표현식 객체의 프로퍼티 이름에 오타가 있었습니다.
![스크린샷 2021-07-08 오후 4 30 26](https://user-images.githubusercontent.com/35324795/124880973-d05cc400-e009-11eb-9bd4-bd66129ccd64.png)

## 추가 구현 필요사항
뒤로가기 버튼 구현시 `<a>` 태그보다 `window.history.back` 함수 사용 고려

## 스크린샷
![스크린샷 2021-07-08 오후 4 26 16](https://user-images.githubusercontent.com/35324795/124880412-3ac13480-e009-11eb-816f-9af1da7a64f9.png)
