### PR TITLE
Feature: 가입-약관 동의 화면 서버 로직 구현

### DIFF
--- a/baemin-register/models/account/sqlite/SQLITE3AccountStore.js
+++ b/baemin-register/models/account/sqlite/SQLITE3AccountStore.js
@@ -19,7 +19,6 @@ export class SQLITE3AccountStore extends AbstractAccountStore {
 
   async create(id, password, phonenumber, nickname, dateOfBirth) {
     const db = await connectDB();
-    // TODO: Add Hashing password using bcrypt.
     const account = new Account(
       id,
       password,

--- a/baemin-register/models/register/RegisterInfo.js
+++ b/baemin-register/models/register/RegisterInfo.js
@@ -1,0 +1,21 @@
+const _account_isAgreeTerms = Symbol("isAgreeTerms");
+const _account_phoneNumber = Symbol("phoneNumber");
+
+export class RegisterInfo {
+  constructor() {
+    this[_account_isAgreeTerms] = false;
+    this[_account_phoneNumber] = null;
+  }
+  get isAgreeTerms() {
+    return this[_account_isAgreeTerms];
+  }
+  get phoneNumber() {
+    return this[_account_phoneNumber];
+  }
+  set isAgreeTerms(agree) {
+    this[_account_isAgreeTerms] = Boolean(agree);
+  }
+  set phoneNumber(phoneNumber) {
+    this[_account_phoneNumber] = phoneNumber;
+  }
+}

--- a/baemin-register/public/stylesheets/registerTerms.css
+++ b/baemin-register/public/stylesheets/registerTerms.css
@@ -144,3 +144,11 @@ header > .title {
 .next-step-btn:disabled {
   background-color: var(--disabled-color);
 }
+
+.error-msg {
+  margin-top: 1rem;
+  display: block;
+  text-align: center;
+  color: var(--pink-color);
+  font-size: 2rem;
+}

--- a/baemin-register/routes/auth.js
+++ b/baemin-register/routes/auth.js
@@ -1,11 +1,21 @@
 import express from "express";
 import { compare } from "../models/util/security.js";
 import { AccountStore } from "../app.js";
+import { RegisterInfo } from "../models/register/RegisterInFo.js";
 
+/**
+ * This constant variable means key for accessing login account info.
+ */
 const SESSION_AUTH_KEY = "auth";
+
+/**
+ * This constant variable means key for accessing register(sign up) info.
+ */
+const SESSION_REGISTER_KEY = "registering";
 
 const ID_NO_MATCH_MSG = "존재하지 않는 아이디입니다.";
 const PASSWORD_NO_MATCH_MSG = "패스워드가 일치하지않습니다.";
+const TERMS_EMPTY_MSG = "필수 약관동의를 모두 확인해주세요.";
 
 var router = express.Router();
 
@@ -43,11 +53,32 @@ router.post("/login", async function (req, res, next) {
 });
 
 router.get("/registerTerms", function (req, res, next) {
-  res.render("auth/registerTerms", { title: "Register Terms" });
+  const registerInfo = req.session[SESSION_REGISTER_KEY];
+  if (registerInfo) {
+    // Clear previous register infomation.
+    req.session[SESSION_REGISTER_KEY] = null;
+  }
+
+  const accountInSession = req.session[SESSION_AUTH_KEY];
+  if (accountInSession) {
+    res.redirect("/");
+  } else {
+    res.render("auth/registerTerms");
+  }
 });
 
 router.post("/registerTerms", function (req, res, next) {
-  res.redirect("/auth/registerPhone");
+  const { terms_1, terms_2, terms_3, age } = req.body;
+
+  if (terms_1 && terms_2 && terms_3 && age) {
+    const registerInfo = new RegisterInfo();
+    registerInfo.isAgreeTerms = true;
+    req.session[SESSION_REGISTER_KEY] = registerInfo;
+
+    res.redirect("/auth/registerPhone");
+  } else {
+    res.render("auth/registerTerms", { errorMessage: TERMS_EMPTY_MSG });
+  }
 });
 
 router.get("/registerPhone", function (req, res, next) {

--- a/baemin-register/routes/auth.js
+++ b/baemin-register/routes/auth.js
@@ -11,12 +11,10 @@ var router = express.Router();
 
 router.get("/login", function (req, res, next) {
   const accountInSession = req.session[SESSION_AUTH_KEY];
-  console.log("DEBUG - session ", req.session[SESSION_AUTH_KEY]);
-
   if (accountInSession) {
     res.redirect("/");
   } else {
-    res.render("auth/login", { title: "Login", errorMessage: "", id: "" });
+    res.render("auth/login", { title: "Login", id: "", errorMessage: "" });
   }
 });
 
@@ -28,7 +26,6 @@ router.post("/login", async function (req, res, next) {
     const pwcheck = await compare(pw, account.password);
     if (pwcheck) {
       req.session[SESSION_AUTH_KEY] = account;
-
       res.redirect("/");
       return;
     } else {

--- a/baemin-register/routes/auth.js
+++ b/baemin-register/routes/auth.js
@@ -17,7 +17,7 @@ const ID_NO_MATCH_MSG = "존재하지 않는 아이디입니다.";
 const PASSWORD_NO_MATCH_MSG = "패스워드가 일치하지않습니다.";
 const TERMS_EMPTY_MSG = "필수 약관동의를 모두 확인해주세요.";
 
-var router = express.Router();
+const router = express.Router();
 
 router.get("/login", function (req, res, next) {
   const accountInSession = req.session[SESSION_AUTH_KEY];

--- a/baemin-register/routes/index.js
+++ b/baemin-register/routes/index.js
@@ -1,5 +1,6 @@
 import express from "express";
-var router = express.Router();
+
+const router = express.Router();
 
 const SESSION_AUTH_KEY = "auth";
 

--- a/baemin-register/views/auth/login.ejs
+++ b/baemin-register/views/auth/login.ejs
@@ -13,7 +13,6 @@
     <div class="container">
       <header>
         <div class="left">
-          <!-- TODO: Back ICON -->
           <a class="left--back-btn" href="/"><i class="fas fa-times"></i></a>
         </div>
         <div class="title"></div>

--- a/baemin-register/views/auth/registerTerms.ejs
+++ b/baemin-register/views/auth/registerTerms.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= title %></title>
+    <title>회원가입 - 약관동의</title>
     <script
       src="https://kit.fontawesome.com/3b8424c68a.js"
       crossorigin="anonymous"
@@ -33,7 +33,7 @@
           <hr />
 
           <div class="check-container">
-            <input type="checkbox" id="terms-1"  name="terms-1" class="essential-terms" />
+            <input type="checkbox" id="terms-1"  name="terms_1" class="essential-terms" />
             <label for="terms-1">배달의 민족 이용약관 동의</label>
             <button class="check-container--detail-arrow">
               <i class="fas fa-chevron-right"></i>
@@ -41,7 +41,7 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="terms-2" name="terms-2" class="essential-terms" />
+            <input type="checkbox" id="terms-2" name="terms_2" class="essential-terms" />
             <label for="terms-2">전자금융거래 이용약관 동의</label>
             <button class="check-container--detail-arrow">
               <i class="fas fa-chevron-right"></i>
@@ -49,7 +49,7 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="terms-3" name="terms-3" class="essential-terms" />
+            <input type="checkbox" id="terms-3" name="terms_3" class="essential-terms" />
             <label for="terms-3">개인정보 수집이용 동의</label>
             <button class="check-container--detail-arrow">
               <i class="fas fa-chevron-right"></i>
@@ -57,7 +57,7 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="option-terms-1" name="option-terms-1" />
+            <input type="checkbox" id="option-terms-1" name="option_terms_1" />
             <label for="option-terms-1"
               >개인정보 제3자 제공 동의 (선택)</label
             >
@@ -67,7 +67,7 @@
           </div>
 
           <div class="check-container">
-            <input type="checkbox" id="option-terms-2" name="option-terms-2" />
+            <input type="checkbox" id="option-terms-2" name="option_terms_2" />
             <label for="option-terms-2"
               >마케팅 정보 메일, SMS 수신 동의 (선택)</label
             >
@@ -94,7 +94,11 @@
               </p>
             </label>
           </div>
-          <input id="terms-submit-btn" type="submit" class="next-step-btn" value="다음으로" disabled></button>
+          <% if (locals.errorMessage) { %>
+            <span class="error-msg"><%= errorMessage %></span>
+          <% } %>
+          <input id="terms-submit-btn" type="submit" class="next-step-btn" value="다음으로" disabled>
+          </button>
         </form>
       </main>
     </div>


### PR DESCRIPTION
#19 

## 개요

가입 약관 동의 화면에서 회원가입 절차가 시작되는 백엔드 로직을 작성했습니다.

## 변경사항

Session 에 RegisterInfo 라는 Class를 통해 생성한 객체를 두고 절차대로 해당 객체를 수정하는 방식을 정했습니다.

단순히 Key만 상수화해서 처리하기 보다 여러개의 값이 들어갈 가능성이 있어서 이렇게 처리했습니다.

- models/RegisterInfo
```
export class RegisterInfo {
  constructor() {
    this[_account_isAgreeTerms] = false;
    this[_account_phoneNumber] = null;
  }
 // getter, setter
}
```


## 참고사항

Session관련 설정을 조사해서 제대로 확인해봐야합니다.

## 추가 구현 필요사항
## 스크린샷

따로 없습니다. 