### PR TITLE
Update: UI 코드 맞추기

### DIFF
--- a/public/stylesheets/common/mobile.css
+++ b/public/stylesheets/common/mobile.css
@@ -12,6 +12,8 @@
 body {
   display: flex;
   justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
 }
 
 div, h1, h2, h3, h4, h5, h6, button, a {
@@ -19,20 +21,38 @@ div, h1, h2, h3, h4, h5, h6, button, a {
 }
 
 .container {
+  position: relative;
   width: 100vw;
+  min-height: 100vh;
   background-color: var(--background-color);
+  display: flex;
+  flex-direction: column;
 }
 
 header {
   box-sizing: border-box;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  height: 50px;
+  min-height: 50px;
   width: 100%;
   background-color: white;
   padding: 0 24px;
+  position: relative;
 }
+
+header > .left,
+header > .right {
+  position: absolute;
+  cursor: pointer;
+}
+header > .left {
+  left: 24px;
+}
+header > .right {
+  right: 24px;
+}
+
 
 .underline {
   border-bottom: 1px solid var(--background-color);

--- a/public/stylesheets/index.css
+++ b/public/stylesheets/index.css
@@ -40,18 +40,21 @@ section {
 }
 .wide-button__title-container > .title {
   font-weight: 500;
-  font-size: 16px;
+  font-size: 1rem;
 }
 .wide-button__title-container > .big {
   font-weight: 400;
-  font-size: 20px;
+  font-size: 1.25rem;
   color: var(--sub-text-color);
+}
+.wide-button__title-container > .big > .username {
+  color: var(--text-color);
 }
 .wide-button__title-container > .green {
   color: var(--green-color);
 }
 .wide-button__title-container > .subtitle {
-  font-size: 14px;
+  font-size: 0.8rem;
   color: var(--sub-text-color);
   margin-top: 5px;
 }
@@ -65,7 +68,7 @@ section {
   margin-left: 5px;
   background-color: var(--pink-color);
   color: white;
-  font-size: 6px;
+  font-size: 0.4rem;
   padding: 4px;
   border-radius: 12px;
 }
@@ -102,7 +105,7 @@ section {
   margin-bottom: 5px;
 }
 .grid-button__text {
-  font-size: 10px;
+  font-size: 0.6rem;
   color: var(--sub-text-color);
 }
 

--- a/public/stylesheets/login.css
+++ b/public/stylesheets/login.css
@@ -1,73 +1,64 @@
 @import url("common/reset.css");
 @import url("common/mobile.css");
 
-:root {
-  --main-mint-color: #28c0bc;
-}
-
 /* mobile.css override */
-
-body {
-  align-items: flex-start;
-  height: 100vh;
-}
-
 .container {
-  position: relative;
   background-color: white;
-  height: 100%;
-  border: none;
-}
-
-header {
-  width: 100%;
-  height: 10%;
 }
 
 header > .left {
-  font-size: 3rem;
-  padding: 1rem;
+  font-size: 1rem;
 }
 
 .left--back-btn {
   text-decoration: none;
   color: black;
 }
-
 .left--back-btn:visited {
   color: black;
 }
 
 /* Style for Login */
+main {
+  box-sizing: border-box;
+  height: calc(100vh - 50px);
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
 .login-form {
   display: flex;
   flex-direction: column;
   margin-top: 20%;
-  margin-right: 5%;
-  margin-left: 5%;
 }
 
 .login-form--id-input,
-.login-form--pw-input,
-.login-form--submit-btn {
-  margin: 2rem 0;
-  padding: 2rem;
-  font-size: 2rem;
+.login-form--pw-input {
+  margin: 8px 0;
+  padding: 12px 0;
+  font-size: 0.5rem;
   font-weight: bold;
   border-style: none;
-  border-bottom: 2px solid #c0c0c0;
+  border-bottom: 1px solid var(--sub-text-color);
+  font-size: 0.75rem;
+  color: var(--text-color);
+}
+.login-form--id-input::placeholder,
+.login-form--pw-input::placeholder {
+  color: var(--sub-text-color);
 }
 
 .login-form--id-input.error,
 .login-form--pw-input.error {
-  border-bottom: 2px solid var(--alert-color);
+  border-bottom: 1px solid var(--alert-color);
 }
 
 .login-form--id-warning-message,
 .login-form--pw-warning-message {
   color: var(--alert-color);
-  font-size: 2rem;
+  font-size: 0.8rem;
   visibility: collapse;
   text-align: center;
 }
@@ -78,9 +69,11 @@ header > .left {
 }
 
 .login-form--submit-btn {
-  background-color: var(--main-mint-color);
+  padding: 12px 0;
+  background-color: var(--main-color);
   color: white;
-  border-radius: 10px;
+  border-radius: 5px;
+  font-size: 1rem;
 }
 
 .auth-util {
@@ -91,39 +84,39 @@ header > .left {
 
 .auth-util--find-id-link,
 .auth-util--find-pw-link {
-  font-size: 2rem;
+  font-size: 0.8rem;
   color: #c0c0c0;
   padding: 10px;
 }
 
 .split-line {
   content: "|";
-  color: #c0c0c0;
-  font-size: 2rem;
+  color: var(--sub-text-color);
+  font-size: 0.8rem;
   padding: 10px;
 }
 
 footer {
   position: absolute;
   width: 100%;
-  bottom: 2rem;
+  bottom: 12px;
   display: flex;
   justify-content: center;
 }
 
 .register-comment {
-  font-size: 2rem;
-  color: #c0c0c0;
+  font-size: 0.8rem;
+  color: var(--sub-text-color);
 }
 
 .register-comment--link {
   text-decoration: none;
-  margin-left: 1rem;
+  margin-left: 6px;
   color: var(--main-color);
 }
 
 .login-form--result-msg {
   text-align: center;
   color: var(--pink-color);
-  font-size: 2rem;
+  font-size: 0.8rem;
 }

--- a/public/stylesheets/login.css
+++ b/public/stylesheets/login.css
@@ -31,7 +31,7 @@ main {
 .login-form {
   display: flex;
   flex-direction: column;
-  margin-top: 20%;
+  margin-top: 80px;
 }
 
 .login-form--id-input,

--- a/public/stylesheets/registerDetail.css
+++ b/public/stylesheets/registerDetail.css
@@ -11,14 +11,10 @@
   position: relative;
 }
 
-header .left {
-  cursor: pointer;
-}
 header .right {
   font-size: 0.8rem;
   font-weight: 500;
   color: var(--main-color);
-  cursor: pointer;
 }
 header .disabled {
   color: var(--disabled-color);
@@ -26,7 +22,7 @@ header .disabled {
 }
 
 main {
-  padding: 20px 16px;
+  padding: 20px 24px;
 }
 
 .input-container {

--- a/public/stylesheets/registerPhone.css
+++ b/public/stylesheets/registerPhone.css
@@ -16,7 +16,7 @@ header .disabled {
 }
 
 main {
-  padding: 20px 16px;
+  padding: 20px 24px;
   display: flex;
   flex-direction: column;
 }

--- a/public/stylesheets/registerTerms.css
+++ b/public/stylesheets/registerTerms.css
@@ -2,115 +2,96 @@
 @import url("common/mobile.css");
 
 /* mobile.css override */
-
-body {
-  align-items: flex-start;
-  height: 100vh;
-  margin: 0px 2rem;
-}
-
 .container {
-  position: relative;
   background-color: white;
-  border: none;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
 }
 
 main {
-  flex-grow: 1;
-}
-
-header {
-  position: relative;
   display: flex;
-  justify-content: center;
-  width: 100%;
-  height: 10%;
+  flex-direction: column;
+  flex: 1;
+  padding: 20px 24px;
 }
 
 header > .left {
-  position: absolute;
-  left: 0;
-  font-size: 3rem;
-}
-
-header > .title {
-  font-size: 3rem;
-  padding: 1rem;
+  font-size: 1rem;
 }
 
 .left--back-btn {
-  display: flex;
-  justify-content: center;
-  text-align: center;
   text-decoration: none;
   color: black;
 }
-
 .left--back-btn:visited {
   color: black;
 }
 
 /* Style for Register Terms Page */
+form {
+  flex: 1;
+  display: block;
+}
 
 .welcome-message {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-bottom: 2rem;
+  margin-bottom: 12px;
 }
 
 .welcome-message p {
-  margin-top: 2rem;
-  font-size: 3rem;
+  margin-top: 12px;
+  font-size: 1.1rem;
   font-weight: bold;
 }
 
 .check-container {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
+  position: relative;
+  padding-top: 12px;
+  padding-bottom: 12px;
   display: flex;
 }
 
 .check-container > input[type="checkbox"] {
-  width: 3rem;
-  height: 3rem;
+  width: 18px;
+  height: 18px;
 }
 
 .check-container > label {
-  margin-left: 1rem;
-  font-size: 3rem;
-  color: black;
+  margin-left: 12px;
+  font-size: 1rem;
+  text-align: left;
+  color: var(--text-color);
+  transform: translateY(25%);
 }
 
 .check-container--detail-arrow {
   position: absolute;
-  right: 0px;
+  right: 0;
+  transform: translateY(25%);
   background-color: white;
   border-style: none;
-  font-size: 3rem;
+  font-size: 1rem;
 }
 
 .radio-container {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
-  padding-left: 1rem;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 6px;
   display: flex;
   align-items: center;
   background-color: #f6f6f6;
-  border-radius: 15px;
-  margin-top: 20px;
+  border-radius: 10px;
+  margin-top: 12px;
+  min-height: 70px;
 }
 
 .radio-container > input[type="radio"] {
-  width: 3rem;
-  height: 3rem;
+  width: 18px;
+  height: 18px;
 }
 
 .radio-container > label {
-  margin-left: 1rem;
+  margin-left: 6px;
 }
 
 .radio-container--label {
@@ -120,25 +101,24 @@ header > .title {
 }
 
 .radio-container--label--title {
-  font-size: 3rem;
+  font-size: 1.1rem;
 }
 
 .radio-container--label--subtitle {
-  font-size: 2rem;
+  font-size: 0.8rem;
   color: gray;
-  margin-top: 10px;
+  margin-top: 8px;
 }
 
 .next-step-btn {
   position: absolute;
-  bottom: 10px;
-  width: 100%;
-  height: 8%;
-  border-radius: 15px;
-  border-style: none;
+  bottom: 16px;
+  width: calc(100% - 48px);
+  padding: 12px 0;
+  border-radius: 10px;
   background-color: var(--main-color);
   color: white;
-  font-size: 3rem;
+  font-size: 1rem;
 }
 
 .next-step-btn:disabled {
@@ -146,9 +126,9 @@ header > .title {
 }
 
 .error-msg {
-  margin-top: 1rem;
+  margin-top: 6px;
   display: block;
   text-align: center;
   color: var(--pink-color);
-  font-size: 2rem;
+  font-size: 0.8rem;
 }

--- a/views/auth/login.ejs
+++ b/views/auth/login.ejs
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= title %></title>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>배달의민족 - 로그인</title>
     <script
       src="https://kit.fontawesome.com/3b8424c68a.js"
       crossorigin="anonymous"
@@ -13,7 +16,9 @@
     <div class="container">
       <header>
         <div class="left">
-          <a class="left--back-btn" href="/"><i class="fas fa-times"></i></a>
+          <a class="left--back-btn" href="/">
+            <i class="fas fa-times"></i>
+          </a>
         </div>
         <div class="title"></div>
         <div class="right"></div>

--- a/views/auth/registerTerms.ejs
+++ b/views/auth/registerTerms.ejs
@@ -1,13 +1,20 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/stylesheets/registerTerms.css" />
     <title>회원가입 - 약관동의</title>
     <script
       src="https://kit.fontawesome.com/3b8424c68a.js"
       crossorigin="anonymous"
     ></script>
-    <link rel="stylesheet" href="/stylesheets/registerTerms.css" />
-    <script type="module" defer src="/javascripts/registerTerms/index.js"></script>
+    <script
+      type="module"
+      defer
+      src="/javascripts/registerTerms/index.js"
+    ></script>
   </head>
   <body>
     <div class="container">
@@ -27,7 +34,7 @@
         <form id="terms-container" class="terms-form" action="/auth/registerTerms" method="POST">
           <div class="check-container">
             <input type="checkbox" id="all-agree-checkbox" name="all-agree-checkbox" />
-            <label for="all-agree-checkbox"> 전체 동의 </label>
+            <label for="all-agree-checkbox">전체 동의</label>
           </div>
 
           <hr />
@@ -98,7 +105,6 @@
             <span class="error-msg"><%= errorMessage %></span>
           <% } %>
           <input id="terms-submit-btn" type="submit" class="next-step-btn" value="다음으로" disabled>
-          </button>
         </form>
       </main>
     </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -34,7 +34,10 @@
                 alt="user-icon"
                 src="/assets/icons/user.png"
               />
-              <h4 class="title big">귀한분, <%= nickname %>님</h4>
+              <h4 class="title big">
+                귀한분,
+                <span class="username"><%= nickname %></span>
+              </h4>
             </div>
           </button>
           <% } else { %>


### PR DESCRIPTION
## 개요
UI 코드를 유사한 컨벤션으로 맞추고 정리

## 변경사항
* 약관동의 페이지, 로그인 페이지 `<meta viewport>` 삽입
* 글자 크기는 `rem`으로, 나머지 길이는 `px`로 맞춤
* 기타 UI 수정

## 참고사항
`px`, `rem` 등 길이와 관련된 내용 추후에 위키에 정리 예정

## 추가 구현 필요사항

## 스크린샷
![스크린샷 2021-07-09 오전 11 08 05](https://user-images.githubusercontent.com/35324795/125012928-f20b8900-e0a5-11eb-9e38-0402fa1c4421.png)
![스크린샷 2021-07-09 오전 11 08 17](https://user-images.githubusercontent.com/35324795/125012944-f89a0080-e0a5-11eb-800c-175244b6b467.png)
![스크린샷 2021-07-09 오전 11 08 28](https://user-images.githubusercontent.com/35324795/125012965-ff287800-e0a5-11eb-9476-e65dded16fcf.png)
![스크린샷 2021-07-09 오전 11 09 00](https://user-images.githubusercontent.com/35324795/125013013-11a2b180-e0a6-11eb-87d3-faa57e9fed86.png)
![스크린샷 2021-07-09 오전 11 09 28](https://user-images.githubusercontent.com/35324795/125013056-22ebbe00-e0a6-11eb-8c74-89d85d6fc2aa.png)

